### PR TITLE
Bugfix/nuxt overtaking dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook-vue/nuxt",
-  "version": "0.0.1-beta.21",
+  "version": "0.0.1-beta.22",
   "description": "Storybook for Nuxt and Vite: Develop Vue3 components in isolation with Hot Reloading.",
   "keywords": [
     "storybook",

--- a/src/runtime/plugins/storybook.ts
+++ b/src/runtime/plugins/storybook.ts
@@ -10,13 +10,13 @@ export default defineNuxtPlugin({
     name: 'storybook-nuxt-plugin',
     enforce: 'pre', // or 'post'
 
-    setup(nuxtApp) {
+    setup(nuxtApp: any) {
    
       if(nuxtApp.globalName !== 'nuxt')
       return
     
       const applyNuxtPlugins = async (vueApp: App,storyContext:any) => {
-        const nuxt = createNuxtApp({vueApp, globalName: storyContext.id})
+        const nuxt = createNuxtApp({vueApp, globalName: `nuxt-${storyContext.id}`})
         nuxt.callHook('app:created', vueApp)
         for (const plugin of plugins) {
           try{
@@ -36,10 +36,7 @@ export default defineNuxtPlugin({
     },
   
     hooks: {
-      'app:created'(nuxtApp)  {
-
-
-      },
+      'app:created'(nuxtApp: any)  {},
     }
 })
 


### PR DESCRIPTION
Hi @chakAs3 

I added a prefix to globalName in createNuxtApp of storybook.ts.

Why is it needed?
Sometimes the nuxt app overtakes the DOM of the story and displays the nuxt application instead of the storybook story in the iframe. 

This way it should be ensured to be unique and nuxt should not take over the DOM anymore and deployments to Vercel should work again.