### PR TITLE
fix: fix error "No builder configured in core."

### DIFF
--- a/packages/storybook-nuxt/preset.js
+++ b/packages/storybook-nuxt/preset.js
@@ -1,1 +1,1 @@
-module.require('./dist/preset.cjs')
+module.exports = require('./dist/preset');

--- a/packages/storybook-nuxt/preset.js
+++ b/packages/storybook-nuxt/preset.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/preset');
+module.exports = require('./dist/preset.cjs');


### PR DESCRIPTION
Fixes https://github.com/storybook-vue/storybook-nuxt/issues/61 by using the standard structure of these preset imports (compare eg https://github.com/storybookjs/storybook/blob/next/code/frameworks/vue3-vite/preset.js)