### PR TITLE
fix: change builddir

### DIFF
--- a/packages/storybook-nuxt/src/preset.ts
+++ b/packages/storybook-nuxt/src/preset.ts
@@ -54,6 +54,7 @@ async function defineNuxtConfig(baseConfig: Record<string, any>) {
     dev: false,
 
     overrides: {
+      buildDir: '.nuxt-storybook',
       ssr: false,
     },
   })


### PR DESCRIPTION
Hi :wave:

This PR change overrides the buildDir. The reason is that when using `@nuxtjs/storybook`, 2 nuxt server are started (almost at the same time) and the main one can conflict with the build started by storybook-nuxt because storybook-nuxt will likely delete and re-write the `.nuxt` build directory.


This PR can probably be improved by allowing to change the arguments sent to `loadNuxt()` and then letting `@nuxt/storybook` assign another `buildDir` itself.